### PR TITLE
Добавлен расчет ширину ячеек <td>

### DIFF
--- a/js/jquery.stickytableheaders.js
+++ b/js/jquery.stickytableheaders.js
@@ -121,6 +121,13 @@
 				$this.css('width', $origCell.width());
 				$this.css('height', $origCell.height());
 			});
+			$('td', base.$clonedHeader).each(function (index) {
+				var $this = $(this);
+				var $origCell = $('td', base.$originalHeader).eq(index);
+				this.className = $origCell.attr('class') || '';				
+				$this.css('width', $origCell.width());
+				$this.css('height', $origCell.height());
+			});
 
 			// Copy row width from whole table
 			base.$clonedHeader.css('width', base.$originalHeader.width());


### PR DESCRIPTION
jquery.stickytableheaders.js

$('td', base.$clonedHeader).each(function (index) {
                var $this = $(this);
                var $origCell = $('td', base.$originalHeader).eq(index);
                this.className = $origCell.attr('class') || '';  
                $this.css('width', $origCell.width());
                $this.css('height', $origCell.height());
            });
